### PR TITLE
Successfully adds sendMessageStreaming endpoint

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -373,6 +373,8 @@ export async function loadCliConfig(
   let mcpServers = mergeMcpServers(settings, activeExtensions);
   const a2aServers = settings.a2aServers;
 
+  console.log("a2aServers", JSON.stringify(a2aServers))
+
   if (a2aServers && a2aServers.length > 0) {
     if (!mcpServers['a2a-server']) {
       // Avoid overwriting if user defined manually

--- a/packages/core/src/a2a/a2a-client.ts
+++ b/packages/core/src/a2a/a2a-client.ts
@@ -10,16 +10,25 @@ import {
   GetTaskResponse,
   MessageSendParams,
   SendMessageResponse,
+  Message,
+  Task,
+  TaskStatusUpdateEvent,
+  TaskArtifactUpdateEvent,
+  // SendStreamingMessageResponse
 } from '@a2a-js/sdk';
 import {
   A2AClient,
   A2AClientOptions,
-  AuthenticationHandler,
-  HttpHeaders,
-  AuthHandlingFetch,
+  // AuthenticationHandler,
+  // HttpHeaders,
+  // AuthHandlingFetch,
 } from '@a2a-js/sdk/client';
 import { extractContextId } from './utils.js';
 import { v4 as uuidv4 } from 'uuid';
+
+// TODO remove, redefining
+type A2AStreamEventData = Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent;
+
 
 const AGENT_CARD_WELL_KNOWN_PATH = '/.well-known/agent-card.json';
 
@@ -68,16 +77,43 @@ export class A2AClientManager {
       agentCardPath: agent_card_path || AGENT_CARD_WELL_KNOWN_PATH,
     };
 
-    if (token) {
-      const staticTokenHandler = new StaticBearerTokenAuth(token);
-      options.fetchImpl = new AuthHandlingFetch(
-        fetch,
-        staticTokenHandler,
-      ) as unknown as typeof fetch;
-    }
+    // Create a single, unified fetch wrapper to handle all header modifications.
+    const customFetch: typeof fetch = (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const headers = new Headers(init?.headers);
+
+      if (headers.get('Accept') === 'text/event-stream') {
+        headers.set('Cache-Control', 'no-cache');
+        headers.set('Connection', 'keep-alive');
+      }
+
+      if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+      }
+
+      const newInit = { ...init, headers };
+
+      // Convert Headers object to a plain object for accurate logging.
+      const headersForLogging: Record<string, string> = {};
+      headers.forEach((value, key) => {
+        headersForLogging[key] = value;
+      });
+      console.error(
+        'Final Fetch Init:',
+        JSON.stringify({ ...newInit, headers: headersForLogging }, null, 2),
+      );
+
+      return fetch(input, newInit);
+    };
+
+    options.fetchImpl = customFetch;
 
     const a2aClient = new A2AClient(url, options);
     const agentCard = await a2aClient.getAgentCard();
+
+    console.error('Loaded agent card:', JSON.stringify(agentCard));
 
     if (this.registeredAgents.has(agentCard.name)) {
       throw Error(`Agent with name ${agentCard.name} is already loaded.`);
@@ -153,6 +189,65 @@ export class A2AClientManager {
   }
 
   /**
+   * Connects to an agent and sends a message, handling the streaming response.
+   * @param agentName The name of the agent.
+   * @param message The message to send.
+   * @returns An async generator that yields events from the stream.
+   */
+  async *sendMessageStreaming(
+    agentName: string,
+    message: string,
+  ): AsyncGenerator<A2AStreamEventData> {
+    const a2aClient = this.registeredAgents.get(agentName);
+    if (!a2aClient) {
+      throw new Error(
+        `Agent with name ${agentName} is not registered. Please run load_agent first.`,
+      );
+    }
+
+    const taskId = uuidv4();
+    this.taskMap.set(
+      agentName,
+      (this.taskMap.get(agentName) || new Set()).add(taskId),
+    );
+
+    const messageParams: MessageSendParams = {
+      message: {
+        kind: 'message',
+        role: 'user',
+        messageId: uuidv4(),
+        parts: [
+          {
+            kind: 'text',
+            text: message,
+          },
+        ],
+        taskId,
+      },
+      configuration: {
+        acceptedOutputModes: ['text'],
+      }
+    };
+
+    console.error('messageParams', JSON.stringify(messageParams))
+
+    const contextId = this.contextMap.get(agentName);
+    if (contextId) messageParams.message.contextId = contextId;
+
+    // TODO: This should be SendStreamingMessageResponse but it is A2AStreamEventData
+    const stream = await a2aClient.sendMessageStream(messageParams);
+
+    for await (const event of stream) {
+      console.error("stream event", event)
+      if (event) {
+        const newContextId = event.contextId;
+        if (newContextId) this.contextMap.set(agentName, newContextId);
+      }
+      yield event;
+    }
+  }
+
+  /**
    * Retrieves a task by its ID.
    * @param taskId The ID of the task.
    * @returns The task object.
@@ -203,28 +298,28 @@ export class A2AClientManager {
   }
 }
 
-// TODO: contribute this to a2a-js/sdk
-class StaticBearerTokenAuth implements AuthenticationHandler {
-  private token: string;
+// // TODO: contribute this to a2a-js/sdk
+// class StaticBearerTokenAuth implements AuthenticationHandler {
+//   private token: string;
 
-  constructor(token: string) {
-    this.token = token;
-  }
+//   constructor(token: string) {
+//     this.token = token;
+//   }
 
-  headers(): HttpHeaders {
-    return {
-      Authorization: `Bearer ${this.token}`,
-    };
-  }
+//   headers(): HttpHeaders {
+//     return {
+//       Authorization: `Bearer ${this.token}`,
+//     };
+//   }
 
-  shouldRetryWithHeaders(
-    _req: RequestInit,
-    _res: Response,
-  ): Promise<HttpHeaders | undefined> {
-    return Promise.resolve(undefined);
-  }
+//   shouldRetryWithHeaders(
+//     _req: RequestInit,
+//     _res: Response,
+//   ): Promise<HttpHeaders | undefined> {
+//     return Promise.resolve(undefined);
+//   }
 
-  onSuccess(_headers: HttpHeaders): Promise<void> {
-    return Promise.resolve();
-  }
-}
+//   onSuccess(_headers: HttpHeaders): Promise<void> {
+//     return Promise.resolve();
+//   }
+// }

--- a/packages/core/src/a2a/a2a-tool-registry.ts
+++ b/packages/core/src/a2a/a2a-tool-registry.ts
@@ -6,7 +6,7 @@
 
 import { z } from 'zod';
 import { A2AClientManager } from './a2a-client.js';
-import { extractMessageText, extractTaskText, textResponse } from './utils.js';
+import { extractMessageText, extractTaskText, textResponse, extractA2AEventStream, A2AStreamEventData } from './utils.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { AgentCard } from '@a2a-js/sdk';
 
@@ -101,7 +101,7 @@ export class A2AToolRegistry {
             agentName,
             args.message,
           );
-          const events: unknown[] = [];
+          const events: A2AStreamEventData[] = [];
           for await (const event of stream) {
             events.push(event);
           }
@@ -109,7 +109,7 @@ export class A2AToolRegistry {
             content: [
               {
                 type: 'text',
-                text: events.map((event) => JSON.stringify(event)).join('\n'),
+                text: events.map((event) => extractA2AEventStream(event)).join('\n'),
               },
             ],
           };


### PR DESCRIPTION
Mostly just a checkpoint. 

TODO: 
• GC a2a server misues taskId as contextId
• should a2 respond with messages maybe instead of status updates that contain messages
• only register tools/set headers based on registered capabilities
• handle removing tasks from map when in a completed state

After:
• Native support (needed for streaming) async generator similar to live shell output?

